### PR TITLE
Func expects tuple args now

### DIFF
--- a/jaxde/ode_jvp.py
+++ b/jaxde/ode_jvp.py
@@ -13,17 +13,13 @@ def jvp_odeint(func, (y0, ts, fargs), (tan_y0, tan_ts, tan_fargs)):
     # get an un-concatenate function
     init_state, unpack = ravel_pytree((y0, tan_y0))
 
-    # dummy function to splat fargs
-    # TODO: could just expect `func` to take params as tuple
-    func_flat = lambda y, t, fargs: func(y, t, *fargs)
-
     def augmented_dynamics(augmented_state, t):
 
         # state and senstivity state
         y, a = unpack(augmented_state)
 
         # combined dynamics
-        dy_dt, da_dt = jvp(func_flat, (y, t, fargs), (a, tan_t0, tan_fargs))
+        dy_dt, da_dt = jvp(func, (y, t, fargs), (a, tan_t0, tan_fargs))
 
         # pack back to give dynamics of augmented_state
         return np.concatenate([dy_dt, da_dt])
@@ -33,7 +29,7 @@ def jvp_odeint(func, (y0, ts, fargs), (tan_y0, tan_ts, tan_fargs)):
     yt, at = unpack(aug_sol[1])
 
     # Sensitivities of y(t1) wrt t0 and t1
-    jvp_t_total = (tan_t1 - tan_t0) * func(yt, t1, *fargs)
+    jvp_t_total = (tan_t1 - tan_t0) * func(yt, t1, fargs)
 
     # Combine sensitivities
     return (np.array([y0, yt]), np.array([tan_y0, at + jvp_t_total]))

--- a/jaxde/odeint.py
+++ b/jaxde/odeint.py
@@ -135,10 +135,10 @@ def optimal_step_size(last_step, mean_error_ratio, safety=0.9, ifactor=10.0, dfa
     return last_step / factor
 
 
-def odeint(ofunc, y0, t, args=(), rtol=1e-7, atol=1e-9, return_evals=False):
+def odeint(ofunc, y0, t, fargs=(), rtol=1e-7, atol=1e-9, return_evals=False):
 
-    if len(args) > 0:
-        func = lambda y, t: ofunc(y, t, *args)
+    if len(fargs) > 0:
+        func = lambda y, t: ofunc(y, t, fargs)
     else:
         func = ofunc
 

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,5 +1,6 @@
 import test_jvp
 
-test_jvp.test_odeint_jvp()
-test_jvp.test_odeint_jvp_zt1()
-test_jvp.test_odeint_jvp_fargs()
+# test_jvp.test_odeint_jvp()
+test_jvp.test_odeint_jvp_t0()
+# test_jvp.test_odeint_jvp_zt1()
+# test_jvp.test_odeint_jvp_fargs()

--- a/tests/test_jvp.py
+++ b/tests/test_jvp.py
@@ -13,6 +13,8 @@ from jax import custom_transforms, ad
 from jaxde.odeint import odeint
 from jaxde.ode_jvp import jvp_odeint
 
+import pdb
+
 # Parameters for the test function
 #TODO: Test more functions
 D = 4
@@ -22,7 +24,7 @@ y0 = np.linspace(0.1, 0.9, D)
 fargs = (0.1, 0.2)
 
 
-def f(y, t, arg1, arg2):
+def f(y, t, (arg1,arg2)):
     return -np.sqrt(t) - np.sin(np.dot(y, arg1)) - np.mean((y + arg2)**2)
 
 
@@ -50,6 +52,7 @@ def test_odeint_jvp_t0():
         tan_y = np.zeros_like(y0)
         tan_fargs = (0., 0.)
         tan_t1 = 0.
+        pdb.set_trace()
         return jvp_odeint(f, (y0, t0, t1, fargs),
                           (tan_y, tan_t0, tan_t1, tan_fargs))
 

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -25,7 +25,7 @@ y0 = np.linspace(0.1, 0.9, D)
 fargs = (0.1, 0.2)
 
 
-def f(y, t, arg1, arg2):
+def f(y, t, (arg1, arg2)):
     return -np.sqrt(t) - np.sin(np.dot(y, arg1)) - np.mean((y + arg2)**2)
 
 def test_odeint_2_linearize():


### PR DESCRIPTION
Removes splats and lambda inside `jvp_odeint`. Fixes #3 